### PR TITLE
Fix sentiment model override

### DIFF
--- a/tools/sentiment_analysis.py
+++ b/tools/sentiment_analysis.py
@@ -4,8 +4,10 @@ from configuration.config import SENTIMENT_MODEL
 
 logger = logging.getLogger(__name__)
 
-# Usa un modello italiano disponibile
-SENTIMENT_MODEL = "neuraly/bert-base-italian-cased-sentiment"
+# Usa il modello specificato nella configurazione. In passato qui veniva
+# sovrascritto il nome del modello, rendendo impossibile la personalizzazione
+# tramite ``config.py``. Ora utilizziamo direttamente il valore proveniente
+# dalla configurazione.
 
 try:
     # Carica il modello e il tokenizer


### PR DESCRIPTION
## Summary
- respect SENTIMENT_MODEL set in `config.py`

## Testing
- `python -m py_compile tools/sentiment_analysis.py`
- `python -m py_compile main.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683ff6b5ac88833196126093777fddf2